### PR TITLE
Config file support - v0.3.0

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [report]
+omit = */test/*
 show_missing = True
 
 exclude_lines =

--- a/README.md
+++ b/README.md
@@ -59,6 +59,40 @@ your Login Session to be - often a full work day.
 
 See the `--reup` commandline option for help here!
 
+## Config file .. predefined settings for you or your org
+
+The config file, which defaults to `~/.config/aws_okta_keyman.yml`, allows you to
+pre-set things like your username, Okta organization name (subdomain), and AWS accounts and App IDs to make this script simpler to use. This also supports username assumption
+based on the current user when the username or email is configured as
+`automatic-username` if usernames only are an option or
+`automatic-username@example.com` if you need full emails. Arguments will always
+be preferred to the config file so you can override what's in the config file
+as needed on each run of the tool.
+
+Example config file:
+
+    username: automatic-username@example.com
+    org: example
+    accounts:
+      - name: Test
+        appid: exampleAppIDFromOkta/123
+      - name: Dev
+        appid: exampleAppIDFromOkta/234
+      - name: Prod
+        appid: exampleAppIDFromOkta/345
+
+When used you'll get a similar interface to AWS Role selection but for your AWS
+accounts:
+
+    $ aws_okta_keyman
+    16:56:47   (INFO) AWS Okta Keyman v0.3.0
+    16:56:47   (WARNING) No app ID provided; please select from available AWS accounts
+    [0] Account: Test
+    [1] Account: Dev
+    [2] Account: Prod
+    Select an account from above: 0
+    16:56:49   (INFO) Using account: Test / exampleAppIDFromOkta/123
+
 # Usage
 
 For detailed usage instructions, see the `--help` commandline argument.

--- a/aws_okta_keyman/aws.py
+++ b/aws_okta_keyman/aws.py
@@ -213,5 +213,7 @@ class Session(object):
             name=self.profile,
             region=self.region,
             creds=self.creds)
+        log.info('Current time is {time}'.format(
+            time=datetime.datetime.utcnow()))
         log.info('Session expires at {time}'.format(
             time=self.creds['Expiration']))

--- a/aws_okta_keyman/config.py
+++ b/aws_okta_keyman/config.py
@@ -1,0 +1,216 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2018 Nextdoor.com, Inc
+# Copyright 2018 Nathan V
+
+import argparse
+import getpass
+import logging
+import os
+
+import yaml
+from aws_okta_keyman.metadata import __version__
+
+log = logging.getLogger(__name__)
+
+
+class Config:
+    def __init__(self, argv):
+        self.argv = argv
+        self.config = None
+        self.writepath = None
+        self.org = None
+        self.accounts = None
+        self.username = None
+        self.reup = None
+        self.debug = None
+        self.appid = None
+        self.name = 'default'
+
+    def set_appid_from_account_id(self, account_id):
+        self.appid = self.accounts[account_id]['appid']
+
+    def validate(self):
+        if self.appid is None:
+            if not self.accounts:
+                raise ValueError('The appid parameter is required if accounts '
+                                 'have not been set in the config file.')
+        required = ['org', 'username']
+        for arg in required:
+            if getattr(self, arg) is None:
+                err = ("The parameter {} must be provided in the config file "
+                       "or as an argument".format(arg))
+                raise ValueError(err)
+
+        self.username = self.username.replace('automatic-username',
+                                              getpass.getuser())
+
+    def get_config(self):
+        file = os.path.expanduser('~') + '/.config/aws_okta_keyman.yml'
+        if '-w' in self.argv[1:] or '--writepath' in self.argv[1:]:
+            self.parse_args(main_required=False)
+            self.write_config()
+        elif '-c' in self.argv[1:] or '--config' in self.argv[1:]:
+            self.parse_args(main_required=False)
+            self.parse_config(self.config)
+        elif os.path.isfile(file):
+            # If we haven't been told to write out the args and no filename is
+            # given just use the default path
+            self.parse_args(main_required=False)
+            self.parse_config(file)
+        else:
+            # No default file, none specified; operate on args only
+            self.parse_args()
+        self.validate()
+
+    def usage_epilog(self):
+        epilog = (
+            '** Application ID **\n'
+            'The ApplicationID is actually a two part piece of the redirect\n'
+            'URL that Okta uses when you are logged into the Web UI. If you\n'
+            'mouse over the appropriate Application and see a URL that looks\n'
+            ' like this. \n'
+            '\n'
+            '\thttps://foobar.okta.com/home/amazon_aws/0oaciCSo1d8/123?...\n'
+            '\n'
+            'You would enter in "0oaciCSo1d8/123" as your Application ID.\n'
+            '\n'
+            '** Configuration File **\n'
+            'AWS Okta Keyman can use a config file to pre-configure most of\n'
+            'the settings needed for execution. The default location is \n'
+            '\'~/.config/aws_okta_keyman.yml\' on Linux/Mac or for Windows \n'
+            'it is \'$USERPROFILE\\.config\\aws_okta_keyman.yml\'\n')
+        return epilog
+
+    def parse_args(self, main_required=True):
+        '''Returns a configured ArgumentParser for the CLI options'''
+        arg_parser = argparse.ArgumentParser(
+            prog=self.argv[0],
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            epilog=self.usage_epilog(),
+            description="AWS Okta Keyman v{}".format(__version__))
+        # Remove the default optional arguments section that always shows up.
+        # It's not necessary, and can cause confusion.
+        #   https://stackoverflow.com/questions/24180527/
+        #   argparse-required-arguments-listed-under-optional-arguments
+        arg_parser._action_groups.pop()
+
+        optional_args = arg_parser.add_argument_group('Optional arguments')
+
+        if main_required:
+            required_args = arg_parser.add_argument_group('Required arguments '
+                                                          'or settings')
+            self.main_args(required_args, main_required)
+        else:
+            self.main_args(optional_args)
+
+        self.optional_args(optional_args)
+
+        config = arg_parser.parse_args(args=self.argv[1:])
+        config_dict = vars(config)
+
+        for key in config_dict:
+            setattr(self, key, config_dict[key])
+
+    @staticmethod
+    def main_args(arg_group, required=False):
+        arg_group.add_argument('-o', '--org', type=str,
+                               help=(
+                                   'Okta Organization Name - ie, if your '
+                                   'login URL is https://foobar.okta.com, '
+                                   'enter in foobar here'
+                               ),
+                               required=required)
+        arg_group.add_argument('-u', '--username', type=str,
+                               help=(
+                                   'Okta Login Name - either '
+                                   'bob@foobar.com, or just bob works too,'
+                                   ' depending on your organization '
+                                   'settings.'
+                               ),
+                               required=required)
+        arg_group.add_argument('-a', '--appid', type=str,
+                               help=(
+                                   'The "redirect link" Application ID  - '
+                                   'this can be found by mousing over the '
+                                   'application in Okta\'s Web UI. See '
+                                   'details below for more help.'
+                               ),
+                               required=required)
+
+    @staticmethod
+    def optional_args(optional_args):
+        optional_args.add_argument('-V', '--version', action='version',
+                                   version=__version__)
+        optional_args.add_argument('-D', '--debug', action='store_true',
+                                   help=(
+                                       'Enable DEBUG logging - note, this is '
+                                       'extremely verbose and exposes '
+                                       'credentials so be careful here!'
+                                   ),
+                                   default=False)
+        optional_args.add_argument('-r', '--reup', action='store_true',
+                                   help=(
+                                       'Automatically re-up the AWS creds '
+                                       'before they expire.'
+                                   ), default=0)
+        optional_args.add_argument('-n', '--name', type=str,
+                                   help='AWS Profile Name', default='default')
+        optional_args.add_argument('-c', '--config', type=str,
+                                   help='Config File path')
+        optional_args.add_argument('-w', '--writepath', type=str,
+                                   help='Full config file path to write to',
+                                   default='~/.config/aws_okta_keyman.yml')
+
+    def parse_config(self, filename):
+        if os.path.isfile(filename):
+            config = yaml.load(open(filename, 'r'))
+        else:
+            raise IOError("File not found: {}".format(filename))
+
+        log.debug("YAML loaded config: {}".format(config))
+
+        for key, value in config.items():
+            if getattr(self, key) is None:  # Only overwrite None not args
+                setattr(self, key, value)
+
+    def write_config(self):
+        file_path = os.path.expanduser(self.writepath)
+        if os.path.isfile(file_path):
+            config = yaml.load(open(file_path, 'r'))
+        else:
+            config = {}
+
+        log.debug("YAML loaded config: {}".format(config))
+
+        args_dict = dict(vars(self))
+
+        # Combine file data and user args with user args overwriting
+        for key, value in config.items():
+            setattr(self, key, value)
+        for key in args_dict:
+            if args_dict[key] is not None:
+                setattr(self, key, args_dict[key])
+
+        config = dict(vars(self))
+        # Remove args we don't want to save to a config file
+        for var in ['name', 'appid', 'argv', 'writepath', 'config', 'debug']:
+            del config[var]
+
+        if config['accounts'] is None:
+            del config['accounts']
+
+        log.debug("YAML being saved: {}".format(config))
+
+        with open(file_path, 'w') as outfile:
+            yaml.safe_dump(config, outfile, default_flow_style=False)

--- a/aws_okta_keyman/metadata.py
+++ b/aws_okta_keyman/metadata.py
@@ -14,7 +14,7 @@
 # Copyright 2018 Nathan V
 
 
-__version__ = '0.2.1'
+__version__ = '0.3.0'
 __desc__ = 'AWS Okta Keyman'
 __desc_long__ = ('''
 ===============

--- a/aws_okta_keyman/okta.py
+++ b/aws_okta_keyman/okta.py
@@ -239,7 +239,7 @@ class Okta(object):
         webbrowser.open_new('http://127.0.0.1:65432/duo.html')
 
         while ret['status'] != 'SUCCESS':
-            log.info('Waiting for Okta Verification...')
+            log.info('Waiting for Duo Auth success...')
             time.sleep(sleep)
 
             if ret.get('factorResult', 'REJECTED') == 'REJECTED':
@@ -341,7 +341,8 @@ class OktaSaml(Okta):
 
         try:
             resp.raise_for_status()
-        except requests.exceptions.HTTPError as e:
+        except (requests.exceptions.HTTPError,
+                requests.exceptions.ConnectionError) as e:
             log.error('Unknown error: {msg}'.format(
                 msg=str(e.response.__dict__)))
             raise UnknownError()

--- a/aws_okta_keyman/test/config_test.py
+++ b/aws_okta_keyman/test/config_test.py
@@ -1,0 +1,383 @@
+from __future__ import unicode_literals
+import unittest
+import os
+import sys
+from aws_okta_keyman.config import Config
+if sys.version_info[0] < 3:  # Python 2
+    import mock
+else:
+    from unittest import mock
+
+
+class ConfigTest(unittest.TestCase):
+
+    @mock.patch('aws_okta_keyman.config.Config.parse_config')
+    @mock.patch('aws_okta_keyman.config.os.path.isfile')
+    def test_set_appid_from_account_id(self, isfile_mock, parse_mock):
+        isfile_mock.return_value = True
+        parse_mock.return_value = None
+        config = Config(['aws_okta_keyman.py'])
+        config.accounts = [{'appid': 'A123'}]
+        config.set_appid_from_account_id(0)
+        self.assertEquals(config.appid, 'A123')
+
+    def test_validate_good_with_accounts(self):
+        config = Config(['aws_okta_keyman.py'])
+        config.accounts = [{'appid': 'A123'}]
+        config.org = 'example'
+        config.username = 'user@example.com'
+        self.assertEquals(config.validate(), None)
+
+    def test_validate_good_with_appid(self):
+        config = Config(['aws_okta_keyman.py'])
+        config.appid = 'A123'
+        config.org = 'example'
+        config.username = 'user@example.com'
+        self.assertEquals(config.validate(), None)
+
+    def test_validate_missing_username(self):
+        config = Config(['aws_okta_keyman.py'])
+        config.accounts = [{'appid': 'A123'}]
+        config.org = 'example'
+        with self.assertRaises(ValueError):
+            config.validate()
+
+    def test_validate_missing_org(self):
+        config = Config(['aws_okta_keyman.py'])
+        config.accounts = [{'appid': 'A123'}]
+        config.username = 'user@example.com'
+        with self.assertRaises(ValueError):
+            config.validate()
+
+    def test_validate_missing_appid_and_accounts(self):
+        config = Config(['aws_okta_keyman.py'])
+        config.username = 'user@example.com'
+        config.org = 'example'
+        with self.assertRaises(ValueError):
+            config.validate()
+
+    @mock.patch('aws_okta_keyman.config.Config.validate')
+    @mock.patch('aws_okta_keyman.config.Config.parse_args')
+    @mock.patch('aws_okta_keyman.config.os.path.isfile')
+    def test_get_config_args_only(self, isfile_mock, parse_mock, valid_mock):
+        isfile_mock.return_value = False
+        parse_mock.return_value = None
+        valid_mock.return_value = None
+
+        argv = [
+            'aws_okta_keyman.py',
+            '-a', 'app/id',
+            '-o', 'foobar',
+            '-u', 'test'
+        ]
+        config = Config(argv)
+        config.get_config()
+        parse_mock.assert_has_calls([
+            mock.call(),
+        ])
+
+    @mock.patch('aws_okta_keyman.config.os.path.expanduser')
+    @mock.patch('aws_okta_keyman.config.Config.parse_config')
+    @mock.patch('aws_okta_keyman.config.Config.validate')
+    @mock.patch('aws_okta_keyman.config.Config.parse_args')
+    @mock.patch('aws_okta_keyman.config.os.path.isfile')
+    def test_get_config_auto_config_only(self, isfile_mock, parse_mock,
+                                         valid_mock, config_mock,
+                                         expuser_mock):
+        isfile_mock.return_value = True
+        parse_mock.return_value = None
+        valid_mock.return_value = None
+        config_mock.return_value = None
+        expuser_mock.return_value = ''
+
+        config = Config(['aws_okta_keyman.py'])
+        config.get_config()
+        parse_mock.assert_has_calls([
+            mock.call(main_required=False),
+        ])
+        config_mock.assert_has_calls([
+            mock.call('/.config/aws_okta_keyman.yml'),
+        ])
+
+    @mock.patch('aws_okta_keyman.config.os.path.expanduser')
+    @mock.patch('aws_okta_keyman.config.Config.parse_config')
+    @mock.patch('aws_okta_keyman.config.Config.validate')
+    @mock.patch('aws_okta_keyman.config.Config.parse_args')
+    @mock.patch('aws_okta_keyman.config.os.path.isfile')
+    def test_get_config_specified_config_only(self, isfile_mock, parse_mock,
+                                              valid_mock, config_mock,
+                                              expuser_mock):
+        isfile_mock.return_value = True
+        valid_mock.return_value = None
+        config_mock.return_value = None
+        expuser_mock.return_value = ''
+
+        config = Config(['aws_okta_keyman.py', '-c'])
+        config.config = '/.config/aws_okta_keyman.yml'
+        config.get_config()
+
+        config_mock.assert_has_calls([
+            mock.call('/.config/aws_okta_keyman.yml'),
+        ])
+
+    @mock.patch('aws_okta_keyman.config.Config.write_config')
+    @mock.patch('aws_okta_keyman.config.os.path.expanduser')
+    @mock.patch('aws_okta_keyman.config.Config.validate')
+    @mock.patch('aws_okta_keyman.config.Config.parse_args')
+    @mock.patch('aws_okta_keyman.config.os.path.isfile')
+    def test_get_config_write_mixed_config(self, isfile_mock, parse_mock,
+                                           valid_mock, expuser_mock,
+                                           write_mock):
+        isfile_mock.return_value = True
+        valid_mock.return_value = None
+        write_mock.return_value = None
+        expuser_mock.return_value = ''
+
+        config = Config(['aws_okta_keyman.py', '-w'])
+        config.get_config()
+        config.write = './.config/aws_okta_keyman.yml'
+
+        self.assertEquals(config.write, './.config/aws_okta_keyman.yml')
+        write_mock.assert_has_calls([
+            mock.call(),
+        ])
+
+    def test_parse_args_no_req_main(self):
+        argv = [
+            'aws_okta_keyman.py',
+            '-D'
+        ]
+        config = Config(argv)
+        config.parse_args(main_required=False)
+
+        # Should succeed without throwing due to missing args
+        self.assertEquals(config.debug, True)
+
+    def test_parse_args_req_main_missing(self):
+        argv = [
+            'aws_okta_keyman.py',
+            '-D'
+        ]
+        config = Config(argv)
+
+        # Main required but not passed, should raise
+        with self.assertRaises(SystemExit):
+            config.parse_args(main_required=True)
+
+    def test_parse_args_req_main_present(self):
+        argv = [
+            'aws_okta_keyman.py',
+            '-a', 'app/id',
+            '-o', 'foobar',
+            '-u', 'test'
+        ]
+        config = Config(argv)
+        config.parse_args(main_required=True)
+
+        # Should succeed without throwing due to missing args
+        self.assertEquals(config.appid, 'app/id')
+        self.assertEquals(config.org, 'foobar')
+        self.assertEquals(config.username, 'test')
+
+    def test_parse_args_verify_all_parsed_short(self):
+        argv = [
+            'aws_okta_keyman.py',
+            '-a', 'app/id',
+            '-o', 'foobar',
+            '-u', 'test',
+            '-n', 'profilename',
+            '-c', 'config_file_path',
+            '-w', 'write_file_path',
+            '-D', '-r'
+        ]
+        config = Config(argv)
+        config.parse_args(main_required=True)
+
+        self.assertEquals(config.appid, 'app/id')
+        self.assertEquals(config.org, 'foobar')
+        self.assertEquals(config.username, 'test')
+        self.assertEquals(config.name, 'profilename')
+        self.assertEquals(config.config, 'config_file_path')
+        self.assertEquals(config.writepath, 'write_file_path')
+        self.assertEquals(config.debug, True)
+        self.assertEquals(config.reup, True)
+
+    def test_parse_args_verify_all_parsed_full(self):
+        argv = [
+            'aws_okta_keyman.py',
+            '--appid', 'app/id',
+            '--org', 'foobar',
+            '--username', 'test',
+            '--name', 'profilename',
+            '--config', 'config_file_path',
+            '--writepath', 'write_file_path',
+            '--debug', '--reup'
+        ]
+        config = Config(argv)
+        config.parse_args(main_required=True)
+
+        self.assertEquals(config.appid, 'app/id')
+        self.assertEquals(config.org, 'foobar')
+        self.assertEquals(config.username, 'test')
+        self.assertEquals(config.name, 'profilename')
+        self.assertEquals(config.config, 'config_file_path')
+        self.assertEquals(config.writepath, 'write_file_path')
+        self.assertEquals(config.debug, True)
+        self.assertEquals(config.reup, True)
+
+    @mock.patch('aws_okta_keyman.config.os.path.isfile')
+    def test_parse_config(self, isfile_mock):
+        isfile_mock.return_value = True
+
+        config = Config(['aws_okta_keyman.py'])
+        yaml = ("username: user@example.com\n"
+                "org: example\n"
+                "appid: app/id\n")
+
+        m = mock.mock_open(read_data=yaml)
+        with mock.patch('aws_okta_keyman.config.open', m):
+                config.parse_config('./.config/aws_okta_keyman.yml')
+
+        self.assertEquals(config.appid, 'app/id')
+        self.assertEquals(config.org, 'example')
+        self.assertEquals(config.username, 'user@example.com')
+
+    @mock.patch('aws_okta_keyman.config.os.path.isfile')
+    def test_parse_config_args_preferred(self, isfile_mock):
+        isfile_mock.return_value = True
+
+        config = Config(['aws_okta_keyman.py'])
+        config.appid = 'mysupercoolapp/id'
+        config.org = 'foobar'
+        config.username = 'test'
+        yaml = ("username: user@example.com\n"
+                "org: example\n"
+                "appid: app/id\n")
+
+        m = mock.mock_open(read_data=yaml)
+        with mock.patch('aws_okta_keyman.config.open', m):
+                config.parse_config('./.config/aws_okta_keyman.yml')
+
+        # Make sure we're getting the args not the config values
+        self.assertEquals(config.appid, 'mysupercoolapp/id')
+        self.assertEquals(config.org, 'foobar')
+        self.assertEquals(config.username, 'test')
+
+    def test_parse_config_file_missing(self):
+        config = Config(['aws_okta_keyman.py'])
+        with self.assertRaises(IOError):
+            config.parse_config('./.config/aws_okta_keyman.yml')
+
+    @mock.patch('aws_okta_keyman.config.os.path.isfile')
+    def test_write_config(self, isfile_mock):
+        isfile_mock.return_value = True
+
+        config = Config(['aws_okta_keyman.py'])
+        config.writepath = './.config/aws_okta_keyman.yml'
+        config.username = 'example@example.com'
+        yaml = ("username: user@example.com\n"
+                "org: example\n"
+                "appid: app/id\n"
+                "accounts:\n"
+                "  - name: Dev\n"
+                "    appid: A123/123\n")
+
+        m = mock.mock_open(read_data=yaml)
+        with mock.patch('aws_okta_keyman.config.open', m):
+                config.write_config()
+
+        m.assert_has_calls([
+            mock.call('./.config/aws_okta_keyman.yml', 'r'),
+        ])
+        m.assert_has_calls([
+            mock.call(u'./.config/aws_okta_keyman.yml', 'w'),
+        ])
+        m.assert_has_calls([
+            mock.call().write('accounts'),
+            mock.call().write(':'),
+            mock.call().write('\n'),
+            mock.call().write('-'),
+            mock.call().write(' '),
+            mock.call().write('appid'),
+            mock.call().write(':'),
+            mock.call().write(' '),
+            mock.call().write('A123/123'),
+            mock.call().write('\n'),
+            mock.call().write('  '),
+            mock.call().write('name'),
+            mock.call().write(':'),
+            mock.call().write(' '),
+            mock.call().write('Dev'),
+            mock.call().write('\n'),
+            mock.call().write('org'),
+            mock.call().write(':'),
+            mock.call().write(' '),
+            mock.call().write('example'),
+            mock.call().write('\n'),
+            mock.call().write('reup'),
+            mock.call().write(':'),
+            mock.call().write(' '),
+            mock.call().write('null'),
+            mock.call().write('\n'),
+            mock.call().write('username'),
+            mock.call().write(':'),
+            mock.call().write(' '),
+            mock.call().write('example@example.com'),
+            mock.call().write('\n'),
+            mock.call().flush(),
+            mock.call().flush(),
+            mock.call().__exit__(None, None, None)
+        ])
+
+    @mock.patch('aws_okta_keyman.config.os.path.isfile')
+    def test_write_config_new_file(self, isfile_mock):
+        isfile_mock.return_value = False
+
+        config = Config(['aws_okta_keyman.py'])
+        config.writepath = './.config/aws_okta_keyman.yml'
+        config.username = 'example@example.com'
+        config.appid = 'app/id'
+        config.org = 'example'
+
+        m = mock.mock_open()
+        with mock.patch('aws_okta_keyman.config.open', m):
+                config.write_config()
+
+        m.assert_has_calls([
+            mock.call().write('org'),
+            mock.call().write(':'),
+            mock.call().write(' '),
+            mock.call().write('example'),
+            mock.call().write('\n'),
+            mock.call().write('reup'),
+            mock.call().write(':'),
+            mock.call().write(' '),
+            mock.call().write('null'),
+            mock.call().write('\n'),
+            mock.call().write('username'),
+            mock.call().write(':'),
+            mock.call().write(' '),
+            mock.call().write('example@example.com'),
+            mock.call().write('\n'),
+            mock.call().flush(),
+            mock.call().flush(),
+            mock.call().__exit__(None, None, None)
+        ])
+
+    @mock.patch('aws_okta_keyman.config.os.path.isfile')
+    def test_write_config_path_expansion(self, isfile_mock):
+        isfile_mock.return_value = False
+
+        config = Config(['aws_okta_keyman.py'])
+        config.writepath = '~/.config/aws_okta_keyman.yml'
+        config.username = 'example@example.com'
+        config.appid = 'app/id'
+        config.org = 'example'
+
+        expected_path = os.path.expanduser(config.writepath)
+
+        m = mock.mock_open()
+        with mock.patch('aws_okta_keyman.config.open', m):
+                config.write_config()
+
+        m.assert_has_calls([mock.call(expected_path, 'w')])

--- a/aws_okta_keyman/test/main_test.py
+++ b/aws_okta_keyman/test/main_test.py
@@ -20,26 +20,9 @@ class MainTest(unittest.TestCase):
         ret = main.setup_logging()
         self.assertEquals(type(ret), type(logging.getLogger()))
 
-    def test_get_config_parser(self):
-        # Simple execution test again - get the argument parser and make sure
-        # it looks reasonably correct. Just validating that this function has
-        # major typos.
-
-        # Also simulates the _required_ options being passed in
-        argv = [
-            'aws_okta_keyman.py',
-            '-a', 'app/id',
-            '-o', 'foobar',
-            '-u', 'test'
-        ]
-        ret = main.get_config_parser(argv)
-        self.assertEquals(ret.org, 'foobar')
-        self.assertEquals(ret.appid, 'app/id')
-        self.assertEquals(ret.username, 'test')
-
     @mock.patch('aws_okta_keyman.aws.Session')
     @mock.patch('aws_okta_keyman.okta.OktaSaml')
-    @mock.patch('aws_okta_keyman.main.get_config_parser')
+    @mock.patch('aws_okta_keyman.main.Config')
     @mock.patch('getpass.getpass')
     def test_entry_point(self, pass_mock, config_mock, okta_mock, aws_mock):
         # Mock out the password getter and return a simple password
@@ -53,7 +36,6 @@ class MainTest(unittest.TestCase):
         fake_parser = mock.MagicMock(name='fake_parser')
         fake_parser.org = 'server'
         fake_parser.username = 'username'
-        fake_parser.username = 'username'
         fake_parser.debug = True
         fake_parser.reup = 0
         config_mock.return_value = fake_parser
@@ -65,7 +47,7 @@ class MainTest(unittest.TestCase):
     @mock.patch('aws_okta_keyman.main.user_input')
     @mock.patch('aws_okta_keyman.aws.Session')
     @mock.patch('aws_okta_keyman.okta.OktaSaml')
-    @mock.patch('aws_okta_keyman.main.get_config_parser')
+    @mock.patch('aws_okta_keyman.config.Config.get_config')
     @mock.patch('getpass.getpass')
     def test_entry_point_mfa(self, pass_mock, config_mock,
                              okta_mock, aws_mock, input_mock):
@@ -121,9 +103,9 @@ class MainTest(unittest.TestCase):
         ])
 
     @mock.patch('aws_okta_keyman.main.user_input')
-    @mock.patch('aws_okta_keyman.aws.Session')
+    @mock.patch('aws_okta_keyman.main.aws.Session')
     @mock.patch('aws_okta_keyman.okta.OktaSaml')
-    @mock.patch('aws_okta_keyman.main.get_config_parser')
+    @mock.patch('aws_okta_keyman.config.Config.get_config')
     @mock.patch('getpass.getpass')
     def test_entry_point_multirole(self, pass_mock, config_mock,
                                    okta_mock, aws_mock, input_mock):
@@ -166,7 +148,7 @@ class MainTest(unittest.TestCase):
         ])
 
     @mock.patch('aws_okta_keyman.okta.OktaSaml')
-    @mock.patch('aws_okta_keyman.main.get_config_parser')
+    @mock.patch('aws_okta_keyman.config.Config.get_config')
     @mock.patch('getpass.getpass')
     def test_entry_point_bad_password(self, pass_mock, config_mock, okta_mock):
         # Mock out the password getter and return a simple password
@@ -185,7 +167,7 @@ class MainTest(unittest.TestCase):
             main.main('test')
 
     @mock.patch('aws_okta_keyman.okta.OktaSaml')
-    @mock.patch('aws_okta_keyman.main.get_config_parser')
+    @mock.patch('aws_okta_keyman.config.Config.get_config')
     @mock.patch('getpass.getpass')
     def test_entry_point_okta_unknown(self, pass_mock, config_mock, okta_mock):
         # Mock out the password getter and return a simple password
@@ -204,7 +186,7 @@ class MainTest(unittest.TestCase):
             main.main('test')
 
     @mock.patch('aws_okta_keyman.okta.OktaSaml')
-    @mock.patch('aws_okta_keyman.main.get_config_parser')
+    @mock.patch('aws_okta_keyman.config.Config.get_config')
     @mock.patch('getpass.getpass')
     def test_entry_point_bad_input(self, pass_mock, config_mock, okta_mock):
         # Pretend that we got some bad input...

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests>=2.10.0
 boto3>=1.4.0
 future==0.16.0
 configparser==3.5.0
+PyYAML>=3.0


### PR DESCRIPTION
* Add support for a configuration file that fills parameters for you
* Allow username to be assumed based on current user name
* Support stored app IDs so the user no longer needs to go check Okta for them
* Support stored organization name
* Update README.md
* Version bump for config file feature

Other:
* Added exception handling if SAML assertion fails to exit cleanly
* Minor text fix in Duo Auth logging
* Adjusted logging in main to be more clear
* Allow user to exit cleanly from the password prompt
* Fix coverage setting to ignore test files