### PR TITLE
feat: Set preferred MFA provider

### DIFF
--- a/aws_okta_keyman/config.py
+++ b/aws_okta_keyman/config.py
@@ -43,6 +43,7 @@ class Config:
         self.appid = None
         self.name = 'default'
         self.oktapreview = None
+        self.region = None
 
     def set_appid_from_account_id(self, account_id):
         """Take an account ID (list index) and sets the appid based on that."""
@@ -196,6 +197,12 @@ class Config:
                                        'production Okta organization.'
                                    ),
                                    default=False)
+        optional_args.add_argument('-R', '--region', type=str,
+                                   help=(
+                                       'Specify a region for the stored '
+                                       'AWS credentials'
+                                   ),
+                                   default='us-east-1')
 
     @staticmethod
     def read_yaml(filename, raise_on_error=False):

--- a/aws_okta_keyman/config.py
+++ b/aws_okta_keyman/config.py
@@ -44,6 +44,7 @@ class Config:
         self.name = 'default'
         self.oktapreview = None
         self.region = None
+        self.provider = None
 
     def set_appid_from_account_id(self, account_id):
         """Take an account ID (list index) and sets the appid based on that."""
@@ -203,6 +204,11 @@ class Config:
                                        'AWS credentials'
                                    ),
                                    default='us-east-1')
+        optional_args.add_argument('-P', '--provider', type=str,
+                                   help=(
+                                        'Use a preferred MFA provider '
+                                        'when multiple providers are present'
+                                   ))
 
     @staticmethod
     def read_yaml(filename, raise_on_error=False):

--- a/aws_okta_keyman/config.py
+++ b/aws_okta_keyman/config.py
@@ -43,7 +43,6 @@ class Config:
         self.appid = None
         self.name = 'default'
         self.oktapreview = None
-        self.region = None
         self.provider = None
 
     def set_appid_from_account_id(self, account_id):
@@ -198,12 +197,6 @@ class Config:
                                        'production Okta organization.'
                                    ),
                                    default=False)
-        optional_args.add_argument('-R', '--region', type=str,
-                                   help=(
-                                       'Specify a region for the stored '
-                                       'AWS credentials'
-                                   ),
-                                   default='us-east-1')
         optional_args.add_argument('-P', '--provider', type=str,
                                    help=(
                                         'Use a preferred MFA provider '

--- a/aws_okta_keyman/keyman.py
+++ b/aws_okta_keyman/keyman.py
@@ -121,12 +121,14 @@ class Keyman:
         """Initialize the Okta client or exit if the client received an empty
         input value
         """
+        oktapreview = self.config.oktapreview
+        provider = self.config.provider
         try:
             self.okta_client = okta_saml.OktaSaml(self.config.org,
                                                   self.config.username,
                                                   password,
-                                                  self.config.oktapreview,
-                                                  self.config.provider)
+                                                  oktapreview=oktapreview,
+                                                  provider=provider)
         except okta.EmptyInput:
             self.log.fatal('Cannot enter a blank string for any input')
             sys.exit(1)
@@ -187,8 +189,7 @@ class Keyman:
             sys.exit(1)
 
         return aws.Session(assertion,
-                           profile=self.config.name,
-                           region=self.config.region)
+                           profile=self.config.name)
 
     def aws_auth_loop(self):
         """Once we're authenticated with an OktaSaml client object we use that

--- a/aws_okta_keyman/keyman.py
+++ b/aws_okta_keyman/keyman.py
@@ -122,16 +122,11 @@ class Keyman:
         input value
         """
         try:
-            if self.config.oktapreview is True:
-                self.okta_client = okta_saml.OktaSaml(self.config.org,
-                                                      self.config.username,
-                                                      password,
-                                                      oktapreview=True)
-            else:
-                self.okta_client = okta_saml.OktaSaml(self.config.org,
-                                                      self.config.username,
-                                                      password)
-
+            self.okta_client = okta_saml.OktaSaml(self.config.org,
+                                                  self.config.username,
+                                                  password,
+                                                  self.config.oktapreview,
+                                                  self.config.provider)
         except okta.EmptyInput:
             self.log.fatal('Cannot enter a blank string for any input')
             sys.exit(1)

--- a/aws_okta_keyman/keyman.py
+++ b/aws_okta_keyman/keyman.py
@@ -191,7 +191,9 @@ class Keyman:
         except okta.UnknownError:
             sys.exit(1)
 
-        return aws.Session(assertion, profile=self.config.name, region=self.config.region)
+        return aws.Session(assertion,
+                           profile=self.config.name,
+                           region=self.config.region)
 
     def aws_auth_loop(self):
         """Once we're authenticated with an OktaSaml client object we use that

--- a/aws_okta_keyman/keyman.py
+++ b/aws_okta_keyman/keyman.py
@@ -191,7 +191,7 @@ class Keyman:
         except okta.UnknownError:
             sys.exit(1)
 
-        return aws.Session(assertion, profile=self.config.name)
+        return aws.Session(assertion, profile=self.config.name, region=self.config.region)
 
     def aws_auth_loop(self):
         """Once we're authenticated with an OktaSaml client object we use that

--- a/aws_okta_keyman/okta.py
+++ b/aws_okta_keyman/okta.py
@@ -360,7 +360,7 @@ class Okta(object):
         """In the case of an MFA response evaluate the response and handle
         accordingly based on available MFA factors.
         """
-        factors = filter_factors(ret['_embedded']['factors'])
+        factors = self.filter_factors(ret['_embedded']['factors'])
 
         response_types = ['sms', 'question', 'call', 'token:software:totp']
         push_factors = []

--- a/aws_okta_keyman/okta.py
+++ b/aws_okta_keyman/okta.py
@@ -104,7 +104,7 @@ class Okta(object):
         self.password = password
         self.session = requests.Session()
         self.session_token = None
-        self.provider = provider.upper()
+        self.provider = provider
 
     def _request(self, path, data=None):
         """Make Okta API calls.
@@ -351,10 +351,14 @@ class Okta(object):
         raise UnknownError(status)
 
     def filter_factors(self, factors):
-        """Filter the list of factors by the preferred provider.
+        """Filter the list of factors by the preferred provider type if set
         """
-        filtered = filter(lambda f: f['provider'] == self.provider, factors)
-        return list(filtered) if self.provider else factors
+        if self.provider is None:
+            return factors
+
+        provider_up = self.provider.upper()
+        filtered = filter(lambda f: f['provider'] == provider_up, factors)
+        return list(filtered)
 
     def handle_mfa_response(self, ret):
         """In the case of an MFA response evaluate the response and handle

--- a/aws_okta_keyman/test/config_test.py
+++ b/aws_okta_keyman/test/config_test.py
@@ -193,7 +193,6 @@ class ConfigTest(unittest.TestCase):
             '-n', 'profilename',
             '-c', 'config_file_path',
             '-w', 'write_file_path',
-            '-R', 'us-west-2',
             '-D', '-r', '-p'
         ]
         config = Config(argv)
@@ -205,7 +204,6 @@ class ConfigTest(unittest.TestCase):
         self.assertEquals(config.name, 'profilename')
         self.assertEquals(config.config, 'config_file_path')
         self.assertEquals(config.writepath, 'write_file_path')
-        self.assertEquals(config.region, 'us-west-2')
         self.assertEquals(config.debug, True)
         self.assertEquals(config.reup, True)
         self.assertEquals(config.oktapreview, True)
@@ -219,7 +217,6 @@ class ConfigTest(unittest.TestCase):
             '--name', 'profilename',
             '--config', 'config_file_path',
             '--writepath', 'write_file_path',
-            '--region', 'us-west-2',
             '--debug', '--reup'
         ]
         config = Config(argv)
@@ -231,7 +228,6 @@ class ConfigTest(unittest.TestCase):
         self.assertEquals(config.name, 'profilename')
         self.assertEquals(config.config, 'config_file_path')
         self.assertEquals(config.writepath, 'write_file_path')
-        self.assertEquals(config.region, 'us-west-2')
         self.assertEquals(config.debug, True)
         self.assertEquals(config.reup, True)
 

--- a/aws_okta_keyman/test/config_test.py
+++ b/aws_okta_keyman/test/config_test.py
@@ -193,6 +193,7 @@ class ConfigTest(unittest.TestCase):
             '-n', 'profilename',
             '-c', 'config_file_path',
             '-w', 'write_file_path',
+            '-R', 'us-west-2',
             '-D', '-r', '-p'
         ]
         config = Config(argv)
@@ -204,6 +205,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEquals(config.name, 'profilename')
         self.assertEquals(config.config, 'config_file_path')
         self.assertEquals(config.writepath, 'write_file_path')
+        self.assertEquals(config.region, 'us-west-2')
         self.assertEquals(config.debug, True)
         self.assertEquals(config.reup, True)
         self.assertEquals(config.oktapreview, True)
@@ -217,6 +219,7 @@ class ConfigTest(unittest.TestCase):
             '--name', 'profilename',
             '--config', 'config_file_path',
             '--writepath', 'write_file_path',
+            '--region', 'us-west-2',
             '--debug', '--reup'
         ]
         config = Config(argv)
@@ -228,6 +231,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEquals(config.name, 'profilename')
         self.assertEquals(config.config, 'config_file_path')
         self.assertEquals(config.writepath, 'write_file_path')
+        self.assertEquals(config.region, 'us-west-2')
         self.assertEquals(config.debug, True)
         self.assertEquals(config.reup, True)
 

--- a/aws_okta_keyman/test/keyman_test.py
+++ b/aws_okta_keyman/test/keyman_test.py
@@ -301,7 +301,7 @@ class KeymanTest(unittest.TestCase):
             mock.call.get_assertion(appid=mock.ANY, apptype='amazon_aws')
         ])
         aws_mock.assert_has_calls([
-            mock.call.Session('assertion', profile=mock.ANY)
+            mock.call.Session('assertion', profile=mock.ANY, region=mock.ANY)
         ])
 
     @mock.patch('aws_okta_keyman.keyman.Config')

--- a/aws_okta_keyman/test/keyman_test.py
+++ b/aws_okta_keyman/test/keyman_test.py
@@ -147,7 +147,11 @@ class KeymanTest(unittest.TestCase):
         keyman.init_okta('troz')
 
         okta_mock.OktaSaml.assert_has_calls([
-            mock.call(mock.ANY, mock.ANY, 'troz')
+            mock.call(mock.ANY,
+                      mock.ANY,
+                      'troz',
+                      oktapreview=mock.ANY,
+                      provider=mock.ANY)
         ])
 
     @mock.patch('aws_okta_keyman.keyman.Config')
@@ -159,7 +163,11 @@ class KeymanTest(unittest.TestCase):
         keyman.init_okta('troz')
 
         okta_mock.OktaSaml.assert_has_calls([
-            mock.call(mock.ANY, mock.ANY, 'troz', oktapreview=True)
+            mock.call(mock.ANY,
+                      mock.ANY,
+                      'troz',
+                      oktapreview=True,
+                      provider=mock.ANY)
         ])
 
     @mock.patch('aws_okta_keyman.keyman.Config')
@@ -301,7 +309,7 @@ class KeymanTest(unittest.TestCase):
             mock.call.get_assertion(appid=mock.ANY, apptype='amazon_aws')
         ])
         aws_mock.assert_has_calls([
-            mock.call.Session('assertion', profile=mock.ANY, region=mock.ANY)
+            mock.call.Session('assertion', profile=mock.ANY)
         ])
 
     @mock.patch('aws_okta_keyman.keyman.Config')


### PR DESCRIPTION
In one of my Okta accounts, I have multiple MFA providers (google, okta verify). I want to be able to specify which one I'd prefer to use when running the tool to make it easier to use. For example, using my "google" one-time password in 1password, instead of opening Okta Verify on my phone.

```
> aws_okta_keyman -o organization -a exampleAppIDFromOkta/234 -u username@example.com -P google

22:54:00   (INFO) AWS Okta Keyman v0.4.0
Password:
22:54:13   (WARNING) MFA Requirement Detected - Enter your GOOGLE code here
MFA Passcode: 111111
22:54:20   (INFO) Successfully authed [...]
22:54:20   (INFO) Getting SAML Assertion from [...]
22:54:21   (INFO) Assuming role: [...]
22:54:22   (INFO) Wrote profile "default" to /Users/[...]/.aws/credentials
22:54:22   (INFO) Current time is 2018-08-30 05:54:22.159636
22:54:22   (INFO) Session expires at 2018-08-30 06:54:22+00:00
```

Open to feedback on how to fix the single code style error. Not sure your preferred format for constructor args.

```
aws_okta_keyman/okta.py:90:80: E501 line too long (91 > 79 characters)
```