### PR TITLE
Fix yaml load warnings.

### DIFF
--- a/aws_okta_keyman/config.py
+++ b/aws_okta_keyman/config.py
@@ -203,7 +203,7 @@ class Config:
         config = {}
         try:
             if os.path.isfile(filename):
-                config = yaml.load(open(filename, 'r'))
+                config = yaml.load(open(filename, 'r'), Loader=yaml.FullLoader)
                 LOG.debug("YAML loaded config: {}".format(config))
             else:
                 if raise_on_error:


### PR DESCRIPTION
When config file option used, pyyaml throwing an error. According to the warning message this small fix should work.

```
/Users/bekzotazimov/py3-venv1/lib/python3.7/site-packages/aws_okta_keyman/config.py:206: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```