### PR TITLE
Automatic AWS Accounts from Okta, Automatic Usernames, v0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![Apache](https://img.shields.io/badge/license-Apache-blue.svg)](https://github.com/nathan-v/aws_okta_keyman/blob/master/LICENSE.txt) [![Python versions](https://img.shields.io/pypi/pyversions/aws-okta-keyman.svg?style=flat-square)](https://pypi.python.org/pypi/aws-okta-keyman/0.2.0) [![PyPI version](https://badge.fury.io/py/aws-okta-keyman.svg)](https://badge.fury.io/py/aws-okta-keyman) ![PyPI - Status](https://img.shields.io/pypi/status/aws_okta_keyman) [![Downloads](http://pepy.tech/badge/aws-okta-keyman)](http://pepy.tech/count/aws-okta-keyman)
+[![Apache](https://img.shields.io/badge/license-Apache-blue.svg)](https://github.com/nathan-v/aws_okta_keyman/blob/master/LICENSE.txt) [![Python versions](https://img.shields.io/pypi/pyversions/aws-okta-keyman.svg)](https://pypi.python.org/pypi/aws-okta-keyman/0.2.0) [![PyPI version](https://badge.fury.io/py/aws-okta-keyman.svg)](https://badge.fury.io/py/aws-okta-keyman) ![PyPI - Status](https://img.shields.io/pypi/status/aws_okta_keyman) [![Downloads](http://pepy.tech/badge/aws-okta-keyman)](http://pepy.tech/count/aws-okta-keyman)
 
 [![CC GPA](https://codeclimate.com/github/nathan-v/aws_okta_keyman/badges/gpa.svg)](https://codeclimate.com/github/nathan-v/aws_okta_keyman) [![CC Issues](https://codeclimate.com/github/nathan-v/aws_okta_keyman/badges/issue_count.svg)](https://codeclimate.com/github/nathan-v/aws_okta_keyman) [![Coverage Status](https://codecov.io/gh/nathan-v/aws_okta_keyman/branch/master/graph/badge.svg)](https://codecov.io/gh/nathan-v/aws_okta_keyman) ![GitHub issues](https://img.shields.io/github/issues-raw/nathan-v/aws_okta_keyman)
 
 [![Requirements Status](https://requires.io/github/nathan-v/aws_okta_keyman/requirements.svg?branch=master)](https://requires.io/github/nathan-v/aws_okta_keyman/requirements/?branch=master) [![Known Vulnerabilities](https://snyk.io/test/github/nathan-v/aws_okta_keyman/badge.svg)](https://snyk.io/test/github/nathan-v/aws_okta_keyman)
 
-[![CircleCI](https://circleci.com/gh/nathan-v/aws_okta_keyman/tree/master.svg?style=svg)](https://circleci.com/gh/nathan-v/aws_okta_keyman/tree/master)
+![CircleCI](https://img.shields.io/circleci/build/gh/nathan-v/aws_okta_keyman)
 
 # AWS Okta Keyman
 
@@ -16,14 +16,15 @@ credentials that can be used for any of the Amazon SDK libraries or CLI tools.
 ## Features
 
 We have support for logging into Okta, optionally handling MFA Authentication,
-and then generating new SAML authenticated AWS sessions. In particular, this
-tool has a few core features.
+and then generating new SAML authenticated AWS sessions. This tool has a few core
+features that help set it apart from other similar tools that are available.
 
 ### Optional MFA Authentication
 
 If you organization requires MFA for the _[initial login into Okta][okta_mfa]_, 
 we will automatically detect that requirement during authentication and prompt
-the user to complete the Multi Factor Authentication.
+the user to complete the Multi Factor Authentication. At this time
+application-level MFA is not supported.
 
 In particular, there is support for standard passcode based auth, as well as
 support for [Okta Verify with Push][okta_verify] and [Duo Auth][duo_auth]. If both
@@ -79,10 +80,25 @@ your Login Session to be - often a full work day.
 
 See the `--reup` commandline option for help here!
 
+
+### AWS Accounts from Okta
+
+As of v0.5.1 AWS Okta Keyman can pull the AWS Accounts that have been assigned
+from Okta itself which means the app ID value no longer needs to be provided in
+the command line or in the config file. A config file can still optionally be used
+to ensure account names or order if preferred.
+
+### Automatic Username
+
+As of v0.5.1 AWS Okta Keyman will use the current user as the username for Okta
+authentication if no username has been provided.
+
+
 ### Config file .. predefined settings for you or your org
 
 The config file, which defaults to `~/.config/aws_okta_keyman.yml`, allows you to
-pre-set things like your username, Okta organization name (subdomain), and AWS accounts and App IDs to make this script simpler to use. This also supports username assumption
+pre-set things like your username, Okta organization name (subdomain), and AWS accounts
+and App IDs to make this script simpler to use. This also supports username assumption
 based on the current user when the username or email is configured as
 `automatic-username` if usernames only are an option or
 `automatic-username@example.com` if you need full emails. Arguments will always

--- a/aws_okta_keyman/metadata.py
+++ b/aws_okta_keyman/metadata.py
@@ -14,19 +14,5 @@
 # Copyright 2018 Nathan V
 """Package metadata."""
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 __desc__ = 'AWS Okta Keyman'
-__desc_long__ = ('''
-===============
-AWS Okta Keyman
-===============
-AWS Okta Keyman is a command-line interface for retrieving temporary
-credentials from AWS for use during development. It authenticates with Okta
-and then retrieves keys from AWS. These are saved in ~/aws/credentials for
-use with other software. AWS Okta Keyman supports multiple MFA solutions.
-
-It's based on `nd_okta_auth <http://github.com/Nextdoor/nd_okta_auth>`_
-by `Nextdoor.com, Inc <https://github.com/Nextdoor>`_.
-
-For more information check out the source on
-`Github <https://github.com/nathan-v/aws_okta_keyman>`_.''')

--- a/aws_okta_keyman/okta_saml.py
+++ b/aws_okta_keyman/okta_saml.py
@@ -48,7 +48,7 @@ class OktaSaml(okta.Okta):
         path = '{url}/home/{apptype}/{appid}'.format(
             url=self.base_url, apptype=apptype, appid=appid)
         resp = self.session.get(path,
-                                params={'onetimetoken': self.session_token})
+                                cookies={'sid': self.session_token})
         LOG.debug(resp.__dict__)
 
         try:

--- a/aws_okta_keyman/test/okta_saml_test.py
+++ b/aws_okta_keyman/test/okta_saml_test.py
@@ -1,0 +1,75 @@
+from __future__ import unicode_literals
+
+import sys
+import unittest
+
+import requests
+
+from aws_okta_keyman.okta import UnknownError
+from aws_okta_keyman.okta_saml import OktaSaml
+
+if sys.version_info[0] < 3:  # Python 2
+    import mock
+else:
+    from unittest import mock
+
+EXAMPLE_ASSERTION = (
+    '<!DOCTYPE html><html lang="en"><body id="app" class="enduser-app">'
+    '<form id="appForm" '
+    'action="https://signin.aws.amazon.com/saml" method="POST">'
+    '<input name="SAMLResponse" type="hidden" value="SAMLSAMLSAML"/>'
+    '<input name="RelayState" type="hidden" value=""/></form></body></html>')
+
+
+class MockResponse:
+    def __init__(self, headers, status_code, text):
+        self.headers = headers
+        self.text = text
+        self.status_code = status_code
+
+    def text(self):
+        return self.text
+
+    def raise_for_status(self):
+        pass
+
+
+class OktaSAMLTest(unittest.TestCase):
+
+    def test_assertion(self):
+        okta_saml = OktaSaml('org', 'user', 'password')
+        ret = okta_saml.assertion(EXAMPLE_ASSERTION)
+        self.assertEqual(ret, b"H\x03\x0bH\x03\x0bH\x03\x0b")
+
+    def test_get_assertion_successful(self):
+        okta_saml = OktaSaml('org', 'user', 'password')
+        okta_saml.assertion = mock.MagicMock()
+        okta_saml.assertion.return_value = 'assertion'
+        okta_saml.session = mock.MagicMock()
+        okta_saml.session.get.return_value = MockResponse(None, None, 'assert')
+        ret = okta_saml.get_assertion('foo', 'bar')
+
+        okta_saml.assertion.assert_has_calls([mock.call('assert')])
+        self.assertEqual(ret, 'assertion')
+
+    def test_get_assertion_404(self):
+        okta_saml = OktaSaml('org', 'user', 'password')
+        okta_saml.assertion = mock.MagicMock()
+        okta_saml.session = mock.MagicMock()
+        resp = requests.Response()
+        resp.status_code = 404
+        okta_saml.session.get.return_value = resp
+
+        with self.assertRaises(UnknownError):
+            okta_saml.get_assertion('foo', 'bar')
+
+    def test_get_assertion_500(self):
+        okta_saml = OktaSaml('org', 'user', 'password')
+        okta_saml.assertion = mock.MagicMock()
+        okta_saml.session = mock.MagicMock()
+        resp = requests.Response()
+        resp.status_code = 500
+        okta_saml.session.get.return_value = resp
+
+        with self.assertRaises(UnknownError):
+            okta_saml.get_assertion('foo', 'bar')

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import sys
 
 from setuptools import Command, find_packages, setup
 
-from aws_okta_keyman.metadata import __desc__, __desc_long__, __version__
+from aws_okta_keyman.metadata import __desc__, __version__
 
 PACKAGE = 'aws_okta_keyman'
 DIR = os.path.dirname(os.path.realpath(__file__))
@@ -83,7 +83,8 @@ setup(
     name=PACKAGE,
     version=__version__,
     description=__desc__,
-    long_description=__desc_long__,
+    long_description=open("{}/README.md".format(DIR)).read(),
+    long_description_content_type='text/markdown',
     author='Nathan V',
     author_email='nathan.v@gmail.com',
     url='https://github.com/nathan-v/aws_okta_keyman',


### PR DESCRIPTION
* AWS Accounts can now be populated from Okta
* Username will now default to the current user when not specified
* Update PyPI description to use REAME.md
* Minor documentation updates
* Tests for okta_saml.py
* Version bump to v0.5.1