### PR TITLE
Support AWS Orgs, interactive config, automatic usernames, Python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ workflows:
   version: 2
   test:
     jobs:
+      - test-3.8
       - test-3.7
       - test-3.6
       - test-3.5
@@ -48,7 +49,7 @@ jobs:
     <<: *test-template
     docker:
       - image: circleci/python:3.7
-
-notify:
-  webhooks:
-    - url: https://coveralls.io/webhook?repo_token=2r3GsmExITkdgJBGEnGquBymNzhex0UWQ
+  test-3.8:
+    <<: *test-template
+    docker:
+      - image: circleci/python:3.8

--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ accounts:
     Select an account from above: 0
     16:56:49   (INFO) Using account: Test / exampleAppIDFromOkta/123
 
+### Interactive Configuration
+
+For interactive configuration and creation of the config file you can start the tool with just config as a parameter and you will be propted to provide the basic information needed to get started.
+
+`aws_okta_keyman config`
+
 ### Python Versions
 
 Python 2.7.4+ and Python 3.5.0+ are supported

--- a/aws_okta_keyman/config.py
+++ b/aws_okta_keyman/config.py
@@ -316,6 +316,6 @@ class Config:
             self.write_config()
             print('')
             LOG.info('Config file written. Please rerun Keyman')
-        except(KeyboardInterrupt):
+        except KeyboardInterrupt:
             print('')
             LOG.warning('User cancelled configuration; exiting')

--- a/aws_okta_keyman/duo.py
+++ b/aws_okta_keyman/duo.py
@@ -130,7 +130,7 @@ class Duo:
         else:
             raise Exception("Requested Duo factor not supported")
         auth = self.get_status(transaction_id, sid)
-        self.okta_callback(auth)
+        return auth
 
     def do_auth(self, sid, certs_url):
         """Handle initial auth with Duo
@@ -178,6 +178,7 @@ class Duo:
         Args:
             sid: String Duo session ID
             factor: String to tell Duo which factor to use
+            passcode: OTP passcode string
 
         Returns:
             String Duo transaction ID
@@ -274,22 +275,3 @@ class Duo:
 
         if 'cookie' in result['response']:
             return result['response']['cookie']
-
-    def okta_callback(self, auth):
-        """Do callback to Okta with the info from Duo
-
-        Args:
-            auth: String authorization from Duo to send in the Okta callback
-        """
-        app = self.details['signature'].split(":")[1]
-        response_sig = "{}:{}".format(auth, app)
-        callback_params = "stateToken={}&sig_response={}".format(
-            self.token, response_sig)
-
-        url = "{}?{}".format(
-            self.details['_links']['complete']['href'],
-            callback_params)
-        ret = self.session.post(url)
-        if ret.status_code != 200:
-            raise Exception("Bad status from Okta callback {}".format(
-                ret.status_code))

--- a/aws_okta_keyman/metadata.py
+++ b/aws_okta_keyman/metadata.py
@@ -14,5 +14,5 @@
 # Copyright 2018 Nathan V
 """Package metadata."""
 
-__version__ = '0.5.1'
+__version__ = '0.5.2'
 __desc__ = 'AWS Okta Keyman'

--- a/aws_okta_keyman/metadata.py
+++ b/aws_okta_keyman/metadata.py
@@ -14,5 +14,5 @@
 # Copyright 2018 Nathan V
 """Package metadata."""
 
-__version__ = '0.5.2'
+__version__ = '0.6.0'
 __desc__ = 'AWS Okta Keyman'

--- a/aws_okta_keyman/test/aws_saml_test.py
+++ b/aws_okta_keyman/test/aws_saml_test.py
@@ -59,6 +59,8 @@ def saml_assertion(roles):
 
 
 class TestSamlAssertion(unittest.TestCase):
+    _multiprocess_can_split_ = True
+
     def test_roles_are_extracted(self):
         assertion = saml_assertion(['{},{}'.format(dev_arn, idp_arn)])
 

--- a/aws_okta_keyman/test/config_test.py
+++ b/aws_okta_keyman/test/config_test.py
@@ -15,6 +15,7 @@ else:
 
 
 class ConfigTest(unittest.TestCase):
+    _multiprocess_can_split_ = True
 
     @mock.patch('aws_okta_keyman.config.sys.exit')
     @mock.patch('aws_okta_keyman.config.Config.interactive_config')
@@ -127,14 +128,14 @@ class ConfigTest(unittest.TestCase):
             mock.call('/.config/aws_okta_keyman.yml'),
         ])
 
+    @mock.patch('aws_okta_keyman.config.Config.parse_args')
     @mock.patch('aws_okta_keyman.config.os.path.expanduser')
     @mock.patch('aws_okta_keyman.config.Config.parse_config')
     @mock.patch('aws_okta_keyman.config.Config.validate')
-    @mock.patch('aws_okta_keyman.config.Config.parse_args')
     @mock.patch('aws_okta_keyman.config.os.path.isfile')
-    def test_get_config_specified_config_only(self, isfile_mock, parse_mock,
-                                              valid_mock, config_mock,
-                                              expuser_mock):
+    def test_get_config_specified_config_only(self, isfile_mock, valid_mock,
+                                              config_mock, expuser_mock,
+                                              _parse_mock):
         isfile_mock.return_value = True
         valid_mock.return_value = None
         config_mock.return_value = None
@@ -181,6 +182,7 @@ class ConfigTest(unittest.TestCase):
         # Should succeed without throwing due to missing args
         self.assertEqual(config.debug, True)
 
+    @mock.patch('argparse.ArgumentParser._print_message', mock.MagicMock())
     def test_parse_args_req_main_missing(self):
         argv = [
             'aws_okta_keyman.py',

--- a/aws_okta_keyman/test/okta_saml_test.py
+++ b/aws_okta_keyman/test/okta_saml_test.py
@@ -21,6 +21,11 @@ EXAMPLE_ASSERTION = (
     '<input name="RelayState" type="hidden" value=""/></form></body></html>')
 
 
+AWS_HTML_ERROR = (
+    '<!DOCTYPE html><html lang="en"><body>'
+    '<div class="error-content"><h1>BAD STUFF</h1></div></body></html>')
+
+
 class MockResponse:
     def __init__(self, headers, status_code, text):
         self.headers = headers
@@ -35,11 +40,26 @@ class MockResponse:
 
 
 class OktaSAMLTest(unittest.TestCase):
+    _multiprocess_can_split_ = True
 
     def test_assertion(self):
         okta_saml = OktaSaml('org', 'user', 'password')
         ret = okta_saml.assertion(EXAMPLE_ASSERTION)
         self.assertEqual(ret, b"H\x03\x0bH\x03\x0bH\x03\x0b")
+
+    def test_get_okta_error_from_response(self):
+        okta_saml = OktaSaml('org', 'user', 'password')
+        response = MockResponse('', 200, 'html')
+        ret = okta_saml.get_okta_error_from_response(response)
+
+        self.assertEqual(ret, 'Unknown error')
+
+    def test_get_okta_error_from_response_specific(self):
+        okta_saml = OktaSaml('org', 'user', 'password')
+        response = MockResponse('', 200, AWS_HTML_ERROR)
+        ret = okta_saml.get_okta_error_from_response(response)
+
+        self.assertEqual(ret, 'BAD STUFF')
 
     def test_get_assertion_successful(self):
         okta_saml = OktaSaml('org', 'user', 'password')
@@ -47,10 +67,24 @@ class OktaSAMLTest(unittest.TestCase):
         okta_saml.assertion.return_value = 'assertion'
         okta_saml.session = mock.MagicMock()
         okta_saml.session.get.return_value = MockResponse(None, None, 'assert')
-        ret = okta_saml.get_assertion('foo', 'bar')
+
+        ret = okta_saml.get_assertion('foo')
 
         okta_saml.assertion.assert_has_calls([mock.call('assert')])
         self.assertEqual(ret, 'assertion')
+
+    def test_get_assertion_missing(self):
+        okta_saml = OktaSaml('org', 'user', 'password')
+        okta_saml.assertion = mock.MagicMock()
+        okta_saml.assertion.return_value = b''
+        okta_saml.session = mock.MagicMock()
+        okta_saml.session.get.return_value = MockResponse(None, None, 'assert')
+        okta_saml.get_okta_error_from_response = mock.MagicMock()
+
+        with self.assertRaises(UnknownError):
+            okta_saml.get_assertion('foo')
+
+        okta_saml.get_okta_error_from_response.assert_has_calls([mock.ANY])
 
     def test_get_assertion_404(self):
         okta_saml = OktaSaml('org', 'user', 'password')
@@ -61,7 +95,7 @@ class OktaSAMLTest(unittest.TestCase):
         okta_saml.session.get.return_value = resp
 
         with self.assertRaises(UnknownError):
-            okta_saml.get_assertion('foo', 'bar')
+            okta_saml.get_assertion('foo')
 
     def test_get_assertion_500(self):
         okta_saml = OktaSaml('org', 'user', 'password')
@@ -72,4 +106,4 @@ class OktaSAMLTest(unittest.TestCase):
         okta_saml.session.get.return_value = resp
 
         with self.assertRaises(UnknownError):
-            okta_saml.get_assertion('foo', 'bar')
+            okta_saml.get_assertion('foo')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[nosetests]
+verbosity=1
+detailed-errors=1
+with-coverage=1
+cover-package=aws_okta_keyman

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
     packages=find_packages(),
     test_suite='nose.collector',
     tests_require=open("{}/test_requirements.txt".format(DIR)).readlines(),
-    setup_requires=[],
+    setup_requires=['nose>=1.3.7'],
     install_requires=open("{}/requirements.txt".format(DIR)).readlines(),
     entry_points={
         'console_scripts': [
@@ -110,10 +110,11 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Operating System :: POSIX',
         'Natural Language :: English',
     ],
-    python_requires='>=2.7.4, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4',
+    python_requires='>=2.7.4, >=3.5.*, <4',
     cmdclass={
         'pycodestyle': PycodestyleCommand,
         'pyflakes': PyflakesCommand,


### PR DESCRIPTION
**Support AWS Orgs, v0.6.0**

* Support AWS Orgs with child accounts
* Show account names in role selection when there are multiple accounts
* Support and automated testing for Python 3.8
* Fix logic bug in Duo Web feature
* Improve test coverage
* Tests can now be run with multiple threads (faster)
* Reduce noise in test output
* Improved error handling and messaging
* Improved user messaging
* Can now run nosetests from setup.py directly without pip installing first
* Simplified python_reqires statement in setup.py

**Add interactive config, v0.5.2**

* Add interactive basic configuration
* Update documentation