### PR TITLE
Add optional password cache for the Okta login, v0.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,23 @@ command line or in the config file. A config file can still optionally be used
 to ensure account names or order if preferred. This means with no configuration
 saved you only need to provide your organization.
 
+
 ### Automatic Username
 
 AWS Okta Keyman will use the current user as the username for Okta
 authentication if no username has been provided.
+
+
+### Keyring Password Cache
+
+AWS Okta Keyman can use your local keyring to store your Okta password to allow you to
+run the tool repeatedly without needing to type your password in each time. For details on how this
+is accomplished check out [keyring][keyring].
+
+```text
+aws_okta_keyman -P    # Enable the password cache
+aws_okta_keyman -R    # Reset the cached password in case of mistaken entry or password change
+```
 
 
 ### Config file .. predefined settings for you or your org
@@ -301,3 +314,4 @@ license is in the LICENSE_MIT.txt file.
 [okta_verify]: https://www.okta.com/blog/tag/okta-verify-with-push/
 [aws_saml]: http://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithSAML.html
 [duo_auth]: https://duo.com/
+[keyring]: https://github.com/jaraco/keyring

--- a/aws_okta_keyman/config.py
+++ b/aws_okta_keyman/config.py
@@ -46,6 +46,8 @@ class Config:
         self.duo_factor = None
         self.name = 'default'
         self.oktapreview = None
+        self.password_cache = None
+        self.password_reset = None
 
         if len(argv) > 1:
             if argv[1] == 'config':
@@ -214,6 +216,18 @@ class Config:
                                        'production Okta organization.'
                                    ),
                                    default=False)
+        optional_args.add_argument('-P', '--password_cache',
+                                   action='store_true', help=(
+                                       'Use OS keyring to cache your password.'
+                                   ),
+                                   default=False)
+        optional_args.add_argument('-R', '--password_reset',
+                                   action='store_true', help=(
+                                       'Reset your password in the cache. '
+                                       'Use this to update the cached password'
+                                       ' if it has changed or is incorrect.'
+                                   ),
+                                   default=False)
 
     @staticmethod
     def read_yaml(filename, raise_on_error=False):
@@ -267,7 +281,7 @@ class Config:
     def clean_config_for_write(config):
         """Remove args we don't want to save to a config file."""
         ignore = ['name', 'appid', 'argv', 'writepath', 'config', 'debug',
-                  'oktapreview']
+                  'oktapreview', 'password_reset']
         for var in ignore:
             del config[var]
 

--- a/aws_okta_keyman/metadata.py
+++ b/aws_okta_keyman/metadata.py
@@ -14,5 +14,5 @@
 # Copyright 2018 Nathan V
 """Package metadata."""
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 __desc__ = 'AWS Okta Keyman'

--- a/aws_okta_keyman/test/config_test.py
+++ b/aws_okta_keyman/test/config_test.py
@@ -508,7 +508,8 @@ class ConfigTest(unittest.TestCase):
             'debug': 'foo',
             'oktapreview': 'foo',
             'accounts': None,
-            'shouldstillbehere': 'woohoo'
+            'shouldstillbehere': 'woohoo',
+            'password_reset': True
         }
         config_out = {
             'shouldstillbehere': 'woohoo'
@@ -530,7 +531,8 @@ class ConfigTest(unittest.TestCase):
             'debug': 'foo',
             'oktapreview': 'foo',
             'accounts': accounts,
-            'shouldstillbehere': 'woohoo'
+            'shouldstillbehere': 'woohoo',
+            'password_reset': True
         }
         config_out = {
             'accounts': accounts,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ boto3>=1.4.0
 future>=0.16.0
 configparser>=3.5.0
 PyYAML>=5.0
+keyring>=18.0.0
+SecretStorage>=2.3.1; python_version == '2.7'
+dbus-python>=1.2.12; python_version == '2.7' and sys_platform == 'linux'


### PR DESCRIPTION
* Add dependency on keyring, SecretStorage, and dbus-python (for 2.7 on linux)
* Use keyring for multi-platform keyring access for password cache
* Update options to support password cache