### PR TITLE
Add region parameter, screen only output option, command wrapper, bug fixes, v0.7.5

### DIFF
--- a/aws_okta_keyman/duo.py
+++ b/aws_okta_keyman/duo.py
@@ -273,3 +273,4 @@ class Duo:
 
         if 'cookie' in result['response']:
             return result['response']['cookie']
+        return None

--- a/aws_okta_keyman/metadata.py
+++ b/aws_okta_keyman/metadata.py
@@ -14,5 +14,5 @@
 # Copyright 2018 Nathan V
 """Package metadata."""
 
-__version__ = '0.7.4'
+__version__ = '0.7.5'
 __desc__ = 'AWS Okta Keyman'

--- a/aws_okta_keyman/okta.py
+++ b/aws_okta_keyman/okta.py
@@ -181,12 +181,13 @@ class Okta(object):
         """
         if len(passcode) > 6 or len(passcode) < 5:
             LOG.error('Passcodes must be 5 or 6 digits')
-            return
+            return None
 
         valid = self.send_user_response(fid, state_token, passcode, 'passCode')
         if valid:
             self.set_token(valid)
             return True
+        return None
 
     def validate_answer(self, fid, state_token, answer):
         """Validate an Okta user with Question-based MFA.
@@ -206,12 +207,13 @@ class Okta(object):
         """
         if not answer:
             LOG.error('Answer cannot be blank')
-            return
+            return None
 
         valid = self.send_user_response(fid, state_token, answer, 'answer')
         if valid:
             self.set_token(valid)
             return True
+        return None
 
     def send_user_response(self, fid, state_token, user_response, resp_type):
         """Call Okta with a factor response and verify it.
@@ -450,6 +452,7 @@ class Okta(object):
             return True
 
         self.handle_response_factors(response_factors, ret['stateToken'])
+        return None
 
     def handle_push_factors(self, factors, state_token):
         """Handle  any push-type factors.
@@ -547,9 +550,9 @@ class Okta(object):
                     if i['appName'] == 'amazon_aws'}
 
         accounts = []
-        for k, v in aws_list.items():
-            appid = v.split("/", 5)[5]
-            accounts.append({'name': k, 'appid': appid})
+        for key, val in aws_list.items():
+            appid = val.split("/", 5)[5]
+            accounts.append({'name': key, 'appid': appid})
         return accounts
 
     def mfa_callback(self, auth, verification, state_token):

--- a/aws_okta_keyman/test/config_test.py
+++ b/aws_okta_keyman/test/config_test.py
@@ -497,6 +497,25 @@ class ConfigTest(unittest.TestCase):
 
         m.assert_has_calls([mock.call(expected_path, 'w')])
 
+    @mock.patch('aws_okta_keyman.config.os')
+    def test_write_config_path_create_when_missing(self, os_mock):
+        config = Config(['aws_okta_keyman.py'])
+        config.clean_config_for_write = mock.MagicMock()
+        config.clean_config_for_write.return_value = {}
+        config.read_yaml = mock.MagicMock()
+        config.read_yaml.return_value = {}
+        folderpath = '/home/user/.config/'
+        os_mock.path.dirname.return_value = folderpath
+        os_mock.path.exists.return_value = False
+
+        m = mock.mock_open()
+        with mock.patch('aws_okta_keyman.config.open', m):
+            config.write_config()
+
+        os_mock.assert_has_calls([
+            mock.call.makedirs(folderpath)
+        ])
+
     def test_clean_config_for_write(self):
         config_in = {
             'name': 'foo',
@@ -508,7 +527,8 @@ class ConfigTest(unittest.TestCase):
             'oktapreview': 'foo',
             'accounts': None,
             'shouldstillbehere': 'woohoo',
-            'password_reset': True
+            'password_reset': True,
+            'command': None
         }
         config_out = {
             'shouldstillbehere': 'woohoo'
@@ -531,7 +551,8 @@ class ConfigTest(unittest.TestCase):
             'oktapreview': 'foo',
             'accounts': accounts,
             'shouldstillbehere': 'woohoo',
-            'password_reset': True
+            'password_reset': True,
+            'command': None
         }
         config_out = {
             'accounts': accounts,
@@ -542,7 +563,7 @@ class ConfigTest(unittest.TestCase):
 
     @mock.patch('aws_okta_keyman.config.input')
     def test_user_input(self, input_mock):
-        input_mock.return_value = 'test'
+        input_mock.return_value = ' test '
         self.assertEqual('test', Config.user_input('input test'))
 
     @mock.patch('aws_okta_keyman.config.getpass')

--- a/aws_okta_keyman/test/duo_test.py
+++ b/aws_okta_keyman/test/duo_test.py
@@ -302,6 +302,17 @@ class TestDuo(unittest.TestCase):
         with self.assertRaises(Exception):
             duo_test.do_redirect('url', 'sid')
 
+    def test_do_redirect_missing_cookie(self):
+        duo_test = duo.Duo(DETAILS, 'token')
+        duo_test.session = mock.MagicMock()
+        json_ok = {'response': {'crumbs': 'yum'}, 'stat': 'OK'}
+        headers = {'Location': 'https://someurl/foo?sid=somesid'}
+        duo_test.session.post.return_value = MockResponse(
+            headers, 200, json_ok)
+        ret = duo_test.do_redirect('url', 'sid')
+
+        self.assertEqual(ret, None)
+
 
 class TestQuietHandler(unittest.TestCase):
     # noinspection PyArgumentList

--- a/aws_okta_keyman/test/okta_test.py
+++ b/aws_okta_keyman/test/okta_test.py
@@ -649,6 +649,16 @@ class OktaTest(unittest.TestCase):
                       'token')
         ])
 
+    def test_handle_mfa_response_returns_none(self):
+        client = okta.Okta('organization', 'username', 'password')
+        client.handle_push_factors = mock.MagicMock()
+        client.handle_push_factors.return_value = False
+        client.handle_response_factors = mock.MagicMock()
+
+        ret = client.handle_mfa_response(MFA_CHALLENGE_SMS_OTP)
+
+        self.assertEqual(ret, None)
+
     def test_handle_mfa_response_unsupported(self):
         client = okta.Okta('organization', 'username', 'password')
         client.handle_push_factors = mock.MagicMock()


### PR DESCRIPTION
* Add optional region parameter which enables use with GovCloud
* Add screen only output for cases where the credentials may need to be copied to another locaiton for use
* Add command wrapper allowing keyman to execute another command for you with the AWS credential env vars provided to the command
* Fix crash in case where ~/.config or a specified config file path does not exist
* Minor code improvements
* Fix user input to trim leading and trailing whitespace
* Version bump to 0.7.5