### PR TITLE
Specified key duration, console login URLs, v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Requirements Status](https://requires.io/github/nathan-v/aws_okta_keyman/requirements.svg?branch=master)](https://requires.io/github/nathan-v/aws_okta_keyman/requirements/?branch=master) [![Known Vulnerabilities](https://snyk.io/test/github/nathan-v/aws_okta_keyman/badge.svg)](https://snyk.io/test/github/nathan-v/aws_okta_keyman)
 
-![CircleCI](https://img.shields.io/circleci/build/gh/nathan-v/aws_okta_keyman)
+[![CircleCI](https://img.shields.io/circleci/build/gh/nathan-v/aws_okta_keyman)](https://circleci.com/gh/nathan-v/aws_okta_keyman/tree/master)
 
 # AWS Okta Keyman
 
@@ -114,6 +114,68 @@ aws_okta_keyman -P    # Enable the password cache
 aws_okta_keyman -R    # Reset the cached password in case of mistaken entry or password change
 ```
 
+### Command Wrapping
+
+Command wrapping provides a simple way to execute any command you would like directly from
+Keyman where the AWS access key environment variables will be provided when starting the
+command. An example of this is provided here:
+
+```text
+$ aws_okta_keyman --command "echo \$AWS_ACCESS_KEY_ID"
+14:06:48 (INFO) AWS Okta Keyman 🔐 v0.7.5
+
+----snip----
+
+14:07:17   (INFO) Assuming role: arn:aws:iam::1234567890:role/Admin
+14:07:17   (INFO) Wrote profile "default" to /home/nathan/.aws/credentials 💾
+14:07:17   (INFO) Current time is 2020-01-10 22:07:17.027964
+14:07:17   (INFO) Session expires at 2020-01-10 23:07:16+00:00 ⏳
+14:07:17   (INFO) Running requested command...
+
+
+AXXXXXXXXXXXXXXXXXXX
+
+```
+
+### Screen-only Key Output
+
+Screen-only output for cases were the key needs to be copied
+elsewhere for use. This makes using the temporary keys in other apps simpler and easier.
+They will not be written out to the AWS credentials file when this option is specified.
+
+```text
+$ aws_okta_keyman --screen
+14:13:27 (INFO) AWS Okta Keyman 🔐 v0.7.5
+
+----snip----
+
+
+14:14:04   (INFO) Assuming role: arn:aws:iam::1234567890:role/Admin
+14:14:04   (INFO) AWS Credentials: 
+
+
+AWS_ACCESS_KEY_ID = AXXXXXXXXXXXXXXXXXXX
+AWS_SECRET_ACCESS_KEY = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+AWS_SESSION_TOKEN = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+
+14:14:04 (INFO) All done! 👍
+```
+
+### GovCloud Support
+AWS Okta Keyman now works with AWS GovCloud. Use the `--region` command-line option
+to specify the AWS region to get the keys from.
+
+### Preferred Key Duration
+You can set a key lifetime other than the default 1 hour by setting `--duration` when calling Keyman.
+If AWS rejects the request for a longer duration the default 1 hour will be used instead. You can request
+key durations from a minimum of 15 minutes (900 seconds) or up to 12 hours (43200 seconds). These
+limits are enforced by AWS and are not a limitation of Keyman.
+
+### AWS Console Logins
+AWS Console login links can optionally be generated when yo request keys with Keyman. 
+The console login link will be output on the screen for you to use. Just provide the `--console`
+parameter when running Keyman.
 
 ### Config file .. predefined settings for you or your org
 
@@ -196,9 +258,12 @@ App ID:
 14:21:58   (INFO) Config file written. Please rerun Keyman
 ```
 
-### Python Versions
+## Python Versions
 
-Python 2.7.4+ and Python 3.5.0+ are supported
+Python 2.7.4+ and Python 3.5.0+ are supported.
+
+Support for older Python versions will be maintained as long as is reasonable.
+Before support is removed a reminder/warning will be provided.
 
 ## Usage
 
@@ -271,7 +336,7 @@ Selection: 0
 ```
 
 
-### Okta Setup
+## Okta Setup
 Before you can use this tool, your Okta administrator needs to set up
 [Amazon/Okta integration][okta_aws_guide] using SAML roles.
 

--- a/aws_okta_keyman/config.py
+++ b/aws_okta_keyman/config.py
@@ -51,11 +51,24 @@ class Config:
         self.command = None
         self.screen = None
         self.region = None
+        self.duration = None
+        self.console = None
 
         if len(argv) > 1:
             if argv[1] == 'config':
                 self.interactive_config()
                 sys.exit(0)
+
+    def full_app_url(self):
+        """ Retrieve the full Okta app URL. """
+        okta_domain = 'okta.com'
+        if self.oktapreview:
+            okta_domain = 'oktapreview.com'
+        full_url = "https://{}.{}/{}".format(
+            self.org,
+            okta_domain,
+            self.appid)
+        return full_url
 
     def set_appid_from_account_id(self, account_id):
         """Take an account ID (list index) and sets the appid based on that."""
@@ -67,6 +80,12 @@ class Config:
             err = ("The parameter org must be provided in the config file "
                    "or as an argument")
             raise ValueError(err)
+        duration = getattr(self, 'duration')
+        if duration:
+            if duration > 43200 or duration < 900:
+                err = ("The parameter duration must be between 900 and 43200 "
+                       "(15m to 12h).")
+                raise ValueError(err)
 
         if self.region is None:
             self.region = 'us-east-1'
@@ -253,6 +272,21 @@ class Config:
                                        'AWS region to use for calls. '
                                        'Required for GovCloud.'
                                    ))
+        optional_args.add_argument('-du', '--duration', type=int,
+                                   help=(
+                                       'AWS API Key duration to request. '
+                                       'If the supplied value is rejected '
+                                       'by AWS the default of 3600s (one '
+                                       'hour) will be used.'
+                                   ),
+                                   default=3600)
+        optional_args.add_argument('-co', '--console',
+                                   action='store_true', help=(
+                                       'Output AWS Console URLs to log in '
+                                       'and use the web conle with the '
+                                       'selected role..'
+                                   ),
+                                   default=False)
 
     @staticmethod
     def read_yaml(filename, raise_on_error=False):

--- a/aws_okta_keyman/keyman.py
+++ b/aws_okta_keyman/keyman.py
@@ -355,7 +355,8 @@ class Keyman:
             self.log.info("Starting AWS session for {}".format(
                 self.config.region))
             session = aws.Session(assertion, profile=self.config.name,
-                                  role=self.role, region=self.config.region)
+                                  role=self.role, region=self.config.region,
+                                  session_duration=self.config.duration)
 
         except xml.etree.ElementTree.ParseError:
             self.log.error('Could not find any Role in the SAML assertion')
@@ -425,5 +426,10 @@ class Keyman:
             )
             self.log.info("Running requested command...\n\n")
             os.system(command_string)
+        elif self.config.console:
+            app_url = self.config.full_app_url()
+            url = session.generate_aws_console_url(app_url)
+            self.log.info("AWS Console URL: {}".format(url))
+
         else:
             self.log.info('All done! 👍')

--- a/aws_okta_keyman/metadata.py
+++ b/aws_okta_keyman/metadata.py
@@ -14,5 +14,5 @@
 # Copyright 2018 Nathan V
 """Package metadata."""
 
-__version__ = '0.7.5'
+__version__ = '0.8.0'
 __desc__ = 'AWS Okta Keyman'

--- a/aws_okta_keyman/test/config_test.py
+++ b/aws_okta_keyman/test/config_test.py
@@ -16,6 +16,23 @@ else:
 
 class ConfigTest(unittest.TestCase):
 
+    def test_full_app_url(self):
+        config = Config(['aws_okta_keyman.py'])
+        config.org = 'example'
+        config.appid = 'some/thing'
+
+        ret = config.full_app_url()
+        self.assertEqual(ret, 'https://example.okta.com/some/thing')
+
+    def test_full_app_url_preview(self):
+        config = Config(['aws_okta_keyman.py'])
+        config.org = 'example'
+        config.appid = 'some/thing'
+        config.oktapreview = True
+
+        ret = config.full_app_url()
+        self.assertEqual(ret, 'https://example.oktapreview.com/some/thing')
+
     @mock.patch('aws_okta_keyman.config.sys.exit')
     @mock.patch('aws_okta_keyman.config.Config.interactive_config')
     def test_start_interactive_config(self, int_mock, exit_mock):
@@ -49,7 +66,6 @@ class ConfigTest(unittest.TestCase):
 
     def test_validate_missing_org(self):
         config = Config(['aws_okta_keyman.py'])
-        config.accounts = [{'appid': 'A123'}]
         config.username = 'user@example.com'
         with self.assertRaises(ValueError):
             config.validate()
@@ -58,7 +74,6 @@ class ConfigTest(unittest.TestCase):
     def test_validate_automatic_username_from_none(self, getpass_mock):
         getpass_mock.getuser.return_value = 'user'
         config = Config(['aws_okta_keyman.py'])
-        config.accounts = [{'appid': 'A123'}]
         config.org = 'example'
         config.validate()
         self.assertEqual(config.username, 'user')
@@ -83,6 +98,22 @@ class ConfigTest(unittest.TestCase):
         config.username = 'automatic-username@example.com'
         config.validate()
         self.assertEqual(config.username, 'user@example.com')
+
+    def test_validate_short_duration(self):
+        config = Config(['aws_okta_keyman.py'])
+        config.org = 'example'
+        config.duration = 1
+
+        with self.assertRaises(ValueError):
+            config.validate()
+
+    def test_validate_long_duration(self):
+        config = Config(['aws_okta_keyman.py'])
+        config.org = 'example'
+        config.duration = 100000000
+
+        with self.assertRaises(ValueError):
+            config.validate()
 
     @mock.patch('aws_okta_keyman.config.Config.validate')
     @mock.patch('aws_okta_keyman.config.Config.parse_args')


### PR DESCRIPTION
* Add ability to specify key duration
* Add optional AWS console login URL output
* Update documentation
* v0.8.0