### PR TITLE
Allow logging configuration from parent

### DIFF
--- a/aws_okta_keyman/keyman.py
+++ b/aws_okta_keyman/keyman.py
@@ -110,7 +110,6 @@ class Keyman:
     def setup_logging():
         """Return back a pretty color-coded logger."""
         logger = logging.getLogger()
-        logger.setLevel(logging.INFO)
         handler = colorlog.StreamHandler()
         fmt = (
             '%(asctime)-8s (%(bold)s%(log_color)s%(levelname)s%(reset)s) '

--- a/aws_okta_keyman/keyman.py
+++ b/aws_okta_keyman/keyman.py
@@ -109,7 +109,7 @@ class Keyman:
     @staticmethod
     def setup_logging():
         """Return back a pretty color-coded logger."""
-        logger = logging.getLogger()
+        logger = logging.getLogger(__name__)
         handler = colorlog.StreamHandler()
         fmt = (
             '%(asctime)-8s (%(bold)s%(log_color)s%(levelname)s%(reset)s) '


### PR DESCRIPTION
I would like to be able to adjust the log verbosity when using keyman as a module. For example:

`keyman_logger = logging.getLogger("aws_okta_keyman")
  keyman_logger.addHandler(logging.StreamHandler(sys.stdout))
  keyman_logger.setLevel(logging.DEBUG)`