### PR TITLE
Support --account and --role to choose the account or role

### DIFF
--- a/aws_okta_keyman/aws.py
+++ b/aws_okta_keyman/aws.py
@@ -179,6 +179,7 @@ class Session(object):
         multiple_accounts = False
         first_account = ''
         formatted_roles = []
+        i = 0
         for role in self.assertion.roles():
             account = role['role'].split(':')[4]
             role_name = role['role'].split(':')[5].split('/')[1]
@@ -186,12 +187,14 @@ class Session(object):
                 'account': account,
                 'role_name': role_name,
                 'arn': role['role'],
-                'principle': role['principle']
+                'principle': role['principle'],
+                'roleIdx': i
             })
             if first_account == '':
                 first_account = account
             elif first_account != account:
                 multiple_accounts = True
+            i = i + 1
 
         if multiple_accounts:
             formatted_roles = self.account_ids_to_names(formatted_roles)

--- a/aws_okta_keyman/config.py
+++ b/aws_okta_keyman/config.py
@@ -54,6 +54,8 @@ class Config:
         self.duration = None
         self.console = None
         self.update = None
+        self.account = None
+        self.role = None
 
         if len(argv) > 1:
             if argv[1] == 'config':
@@ -295,6 +297,14 @@ class Config:
                                        'update if the pip version is newer.'
                                    ),
                                    default=False)
+        optional_args.add_argument('-ac', '--account', type=str,
+                                   help=(
+                                       'AWS account if multiple options. '
+                                   )),
+        optional_args.add_argument('-ro', '--role', type=str,
+                                   help=(
+                                       'AWS role if multiple options. '
+                                   ))
 
     @staticmethod
     def read_yaml(filename, raise_on_error=False):

--- a/aws_okta_keyman/test/aws_test.py
+++ b/aws_okta_keyman/test/aws_test.py
@@ -427,9 +427,11 @@ class TestSession(unittest.TestCase):
         session.assertion.roles.return_value = roles
         expected = [
             {'account': '1', 'role_name': 'role',
-             'principle': '', 'arn': '::::1:role/role'},
+             'principle': '', 'arn': '::::1:role/role',
+             'roleIdx': 0},
             {'account': '1', 'role_name': 'role',
-             'principle': '', 'arn': '::::1:role/role'}
+             'principle': '', 'arn': '::::1:role/role',
+             'roleIdx': 1}
             ]
 
         result = session.available_roles()

--- a/aws_okta_keyman/test/config_test.py
+++ b/aws_okta_keyman/test/config_test.py
@@ -243,9 +243,11 @@ class ConfigTest(unittest.TestCase):
         argv = [
             'aws_okta_keyman.py',
             '-a', 'app/id',
+            '-ac', 'accountname',
             '-o', 'foobar',
             '-u', 'test',
             '-n', 'profilename',
+            '-ro', 'rolename',
             '-c', 'config_file_path',
             '-w', 'write_file_path',
             '-d', 'push',
@@ -255,9 +257,11 @@ class ConfigTest(unittest.TestCase):
         config.parse_args(main_required=True)
 
         self.assertEqual(config.appid, 'app/id')
+        self.assertEqual(config.account, 'accountname')
         self.assertEqual(config.org, 'foobar')
         self.assertEqual(config.username, 'test')
         self.assertEqual(config.name, 'profilename')
+        self.assertEqual(config.role, 'rolename')
         self.assertEqual(config.config, 'config_file_path')
         self.assertEqual(config.writepath, 'write_file_path')
         self.assertEqual(config.duo_factor, 'push')
@@ -268,10 +272,12 @@ class ConfigTest(unittest.TestCase):
     def test_parse_args_verify_all_parsed_full(self):
         argv = [
             'aws_okta_keyman.py',
+            '--account', 'accountname',
             '--appid', 'app/id',
             '--org', 'foobar',
             '--username', 'test',
             '--name', 'profilename',
+            '--role', 'rolename',
             '--config', 'config_file_path',
             '--writepath', 'write_file_path',
             '--duo_factor', 'push',
@@ -280,10 +286,12 @@ class ConfigTest(unittest.TestCase):
         config = Config(argv)
         config.parse_args(main_required=True)
 
+        self.assertEqual(config.account, 'accountname')
         self.assertEqual(config.appid, 'app/id')
         self.assertEqual(config.org, 'foobar')
         self.assertEqual(config.username, 'test')
         self.assertEqual(config.name, 'profilename')
+        self.assertEqual(config.role, 'rolename')
         self.assertEqual(config.config, 'config_file_path')
         self.assertEqual(config.writepath, 'write_file_path')
         self.assertEqual(config.duo_factor, 'push')


### PR DESCRIPTION
# Support --account and --role to choose the account or role
fixes nathan-v/aws_okta_keyman#56

Supplying the --account and/or --role parameters filters the list when
multiple accounts are returned. If the list filters to a single item,
that one used without prompt. If multiple matches occur, a reduced list
is presented.

The primary difference is a change from triggering the call to
handle_multiple_roles on error to checking for multiple accounts up front.

The list of accounts and roles is fetched and filtered. If the filtering
results in multiple accounts/roles, the filtered list is presented for
selection. If only one item is returned, it proceeds with that selection.

## Testing Done:
* 100% test coverage
* attempted with variatons against both a single- and multi-
  account/role okta config