### PR TITLE
Update okta auth to support 3-number challenge when Okta Verify mobile app forces extra verification

### DIFF
--- a/aws_okta_keyman/okta.py
+++ b/aws_okta_keyman/okta.py
@@ -378,10 +378,19 @@ class Okta:
             otherwise None
         """
         try:
+            message = "Waiting for MFA success..."
             while ret["status"] != "SUCCESS":
-                LOG.info("Waiting for MFA success...")
+                LOG.info(message)
                 time.sleep(sleep)
 
+                if ret.get("factorResult", "WAITING") == "WAITING":
+                    correct_answer = (ret.get("_embedded", {})
+                                      .get("factor", {})
+                                      .get("_embedded", {})
+                                      .get("challenge", {})
+                                      .get("correctAnswer", None))
+                    if correct_answer:
+                        message = f'Pick a following number on your device: {correct_answer}'
                 if ret.get("factorResult", "REJECTED") == "REJECTED":
                     LOG.error("Duo Push REJECTED")
                     return None

--- a/aws_okta_keyman/okta.py
+++ b/aws_okta_keyman/okta.py
@@ -384,13 +384,18 @@ class Okta:
                 time.sleep(sleep)
 
                 if ret.get("factorResult", "WAITING") == "WAITING":
-                    correct_answer = (ret.get("_embedded", {})
-                                      .get("factor", {})
-                                      .get("_embedded", {})
-                                      .get("challenge", {})
-                                      .get("correctAnswer", None))
-                    if correct_answer:
-                        message = f'Pick a following number on your device: {correct_answer}'
+                    correct_number = (
+                        ret.get("_embedded", {})
+                        .get("factor", {})
+                        .get("_embedded", {})
+                        .get("challenge", {})
+                        .get("correctAnswer", None)
+                    )
+                    # Okta issued MFA 3-number challenge
+                    if correct_number:
+                        message = (
+                            f"Pick a following number on your device: {correct_number}"
+                        )
                 if ret.get("factorResult", "REJECTED") == "REJECTED":
                     LOG.error("Duo Push REJECTED")
                     return None

--- a/aws_okta_keyman/test/okta_test.py
+++ b/aws_okta_keyman/test/okta_test.py
@@ -161,6 +161,27 @@ MFA_WAITING_RESPONSE = {
         },
     },
 }
+MFA_NUMBER_CHALLENGE_WAITING_RESPONSE = {
+    "status": "MFA_CHALLENGE",
+    "factorResult": "WAITING",
+    "challengeType": "FACTOR",
+    "_links": {
+        "next": {
+            "href": "https://foobar.okta.com/api/v1/authn/factors/X/verify",
+        },
+    },
+    "stateToken": "token",
+    "_embedded": {
+        "factor": {
+            "factorType": "push",
+            "provider": "OKTA",
+            "id": "abcd",
+            "_embedded": {
+                "challenge": {"correctAnswer": 23},
+            },
+        },
+    },
+}
 MFA_REJECTED_RESPONSE = {
     "status": "MFA_CHALLENGE",
     "factorResult": "REJECTED",
@@ -771,7 +792,8 @@ class OktaTest(unittest.TestCase):
         client._request.side_effect = [
             MFA_WAITING_RESPONSE,
             MFA_WAITING_RESPONSE,
-            MFA_WAITING_RESPONSE,
+            MFA_NUMBER_CHALLENGE_WAITING_RESPONSE,
+            MFA_NUMBER_CHALLENGE_WAITING_RESPONSE,
             SUCCESS_RESPONSE,
         ]
         data = {"fid": "123", "stateToken": "token"}


### PR DESCRIPTION
This fixes #81 by pulling the correct number from request embedded data and displaying it in console once Okta Verify makes you pick one of 3 numbers